### PR TITLE
Use a real webserver and setup containers

### DIFF
--- a/Dockerfiles/ApiDockerfile
+++ b/Dockerfiles/ApiDockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+RUN mkdir -p /opt/sawmill/config && \
+    mkdir -p /opt/sawmill/certs && \
+    openssl req -x509 -newkey rsa:2048 -nodes -keyout /opt/sawmill/certs/api.key -out /opt/sawmill/certs/api.cert -days 365 -subj "/CN=localhost" && \
+    chown -R nobody:nogroup opt/sawmill
+COPY api_config.py /opt/sawmill/config/
+COPY dist/sawmill_api-*.whl /
+RUN apt update && apt upgrade -y && \
+    apt-get install -y procps && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    pip install -U pip && pip install -U /sawmill_api-*.whl
+USER nobody
+ENTRYPOINT ["/usr/local/bin/gunicorn"]
+CMD ["--config", "/opt/sawmill/config/api_config.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: clean bootstrap build uninstall install
+.PHONY: clean bootstrap smsh build uninstall install images up
 
 clean:
 	rm -rf build
 	rm -rf dist
 	rm -rf *.egg-info
 	rm -f tests/.coverage
+	docker system prune --force
 
 bootstrap:
 	pip install -U -r requirements-dev.txt
@@ -23,3 +24,9 @@ uninstall:
 
 install: uninstall build
 	pip install ./dist/sawmill_api*.whl
+
+images: build
+	docker build --file Dockerfiles/ApiDockerfile --tag sawmill/api .
+
+up:
+	docker compose up --abort-on-container-failure

--- a/api_config.py
+++ b/api_config.py
@@ -1,0 +1,29 @@
+"""
+Gunicorn WSGI configuation.
+"""
+
+import ssl
+
+
+keepalive = 30  # seconds
+threads = 200
+workers = 1
+wsgi_app = "sawmill_api.app:make_app()"
+bind = "0.0.0.0:8000"
+
+
+# TLS config
+def ssl_context(address, port):
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(
+        keyfile="/opt/sawmill/certs/api.key",
+        certfile="/opt/sawmill/certs/api.cert",
+    )
+    # Disable TLS 1 and 1.1
+    context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+    return context
+
+
+# Logging
+errorlog = "-"  # stderr
+accesslog = "/dev/null"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  api:
+    image: sawmill/api:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./api_config.py:/opt/sawmill/config/api_config.py:ro
+      - ./sawmill_api/:/usr/local/lib/python3.12/site-packages/sawmill_api/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,10 @@ authors = [{ name = "Nicholas Willhite"}]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
+    "antlr4-python3-runtime==4.13.0",
     "Flask==3.1.1",
-    "pydantic==2.11.4"
+    "pydantic==2.11.4",
+    "gunicorn==23.0.0",
 ]
 
 [tool.ruff]
@@ -19,3 +21,7 @@ exclude = [
   "sawmill_api/lib/smsh/SMSHLexer.py",
   "sawmill_api/lib/smsh/SMSHParser.py",
 ]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["sawmill_api*"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 build==1.2.2.post1
 pre_commit==4.2.0
-antlr4-python3-runtime==4.13.0
 antlr4-tools==0.2.2


### PR DESCRIPTION
I've used Gunicorn in the past, and it was fine. Not loving the updated `ssl_context` as a callable; getting to be too much "smarts" in a config file for my taste. Oddly, that's one of the reasons I was looking forward to `pyproject.toml` over a `setup.py` file, only to be constantly frustrated by the defaults of `pyproject.toml`. Sure, yeah, every folder at the same level of my `pyproject.toml` is source code to package up... riiiiiiiight.
![olojf](https://github.com/user-attachments/assets/f73d2e1f-4b8b-49d0-b419-a6c753d78468)


Anyway, this PR containerizes the API and adds some tooling to do dev work with them. Containerizing caught a dependency derp, where things worked on my dev machine because the `requirement-dev.txt` installed `antlr4-python3-runtime` while it was needed as an app dependency. 