### PR TITLE
Add ability to use a transactional database.

### DIFF
--- a/Dockerfiles/ApiDockerfile
+++ b/Dockerfiles/ApiDockerfile
@@ -3,12 +3,12 @@ RUN mkdir -p /opt/sawmill/config && \
     mkdir -p /opt/sawmill/certs && \
     openssl req -x509 -newkey rsa:2048 -nodes -keyout /opt/sawmill/certs/api.key -out /opt/sawmill/certs/api.cert -days 365 -subj "/CN=localhost" && \
     chown -R nobody:nogroup opt/sawmill
-COPY api_config.py /opt/sawmill/config/
 COPY dist/sawmill_api-*.whl /
 RUN apt update && apt upgrade -y && \
-    apt-get install -y procps && \
+    apt-get install -y procps build-essential libpq-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     pip install -U pip && pip install -U /sawmill_api-*.whl
 USER nobody
+WORKDIR /usr/local/lib/python3.12/site-packages/sawmill_api
 ENTRYPOINT ["/usr/local/bin/gunicorn"]
-CMD ["--config", "/opt/sawmill/config/api_config.py"]
+CMD ["--config", "./wsgi.py"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Sawmill API
+
+## Local dev setup
+
+### Prerequisites
+To get started, you'll need Python3, Docker or Podman, the PostgreSQL header files installed (`libpq-dev` for Debian/Ubuntu, `postgresql-libs` for RHEL) and `make`.
+
+It's also **highly** recommened that you setup a [Python virtual environment](https://docs.python.org/3/tutorial/venv.html), but hey, it's your system.
+
+### Run
+
+1. `make bootstrap`
+2. `make images`
+3. `make up`
+ *  To initialize the database, run: `docker compose exec -it oltp-1 ./cockroach --host=oltp-1:26357 init --insecure`
+
+You can now access the API via `https://localhost:8000`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,23 @@
+networks:
+  sawmill:
+    name: sawmill
+
 services:
   api:
     image: sawmill/api:latest
     ports:
       - "8000:8000"
     volumes:
-      - ./api_config.py:/opt/sawmill/config/api_config.py:ro
       - ./sawmill_api/:/usr/local/lib/python3.12/site-packages/sawmill_api/
+  oltp:
+    image: cockroachdb/cockroach:latest-v25.2
+    ports:
+      - "8080:8080"
+      - "26257:26257"
+    environment:
+      - COCKROACH_DATABASE=sawmill
+      - COCKROACH_USER=sawmill
+      - COCKROACH_PASSWORD=a
+    command:
+      - start-single-node
+      - --http-addr=oltp:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,3 @@
-networks:
-  sawmill:
-    name: sawmill
-
 services:
   api:
     image: sawmill/api:latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "Flask==3.1.1",
     "pydantic==2.11.4",
     "gunicorn==23.0.0",
+    "psycopg2==2.9.10"
 ]
 
 [tool.ruff]

--- a/sawmill_api/app.py
+++ b/sawmill_api/app.py
@@ -1,12 +1,24 @@
 from flask import Flask
 
 from sawmill_api.handlers.planks import planks_api
+from sawmill_api import wsgi
+from sawmill_api.lib import oltp
 
 
 def make_app():
     app = Flask(__name__)
     app.url_map.strict_slashes = False
     app.register_blueprint(planks_api)
+    db = oltp.BlockingConnectionPool(
+        host=wsgi.OLTPDatabase.host,
+        port=wsgi.OLTPDatabase.port,
+        user=wsgi.OLTPDatabase.user,
+        password=wsgi.OLTPDatabase.password,
+        dbname=wsgi.OLTPDatabase.dbname,
+        max_connections=wsgi.OLTPDatabase.max_connections,
+    )
+    db.init_app(app)
+
     return app
 
 

--- a/sawmill_api/lib/oltp.py
+++ b/sawmill_api/lib/oltp.py
@@ -1,0 +1,118 @@
+"""
+Interact with an Online Transaction Processing (OLTP) database.
+"""
+
+from collections import deque
+from contextlib import contextmanager
+from threading import Semaphore
+from functools import wraps
+from textwrap import dedent
+
+import psycopg2
+import psycopg2.extras
+
+
+ENGINE = None
+
+
+class BlockingConnectionPool:
+    """
+    A thread safe way to manage database connections.
+    """
+
+    def __init__(self, host, port, user, password, dbname, max_connections=10):
+        self._host = host
+        self._port = port
+        self._user = user
+        self._password = password
+        self._dbname = dbname
+        self._max_connections = max_connections
+        self._pool = deque(
+            (None for _ in range(max_connections)), maxlen=max_connections
+        )
+        self.semaphore = Semaphore(max_connections)
+
+    def init_app(self, app):
+        global ENGINE
+        if ENGINE is None:
+            ENGINE = self
+
+    @contextmanager
+    def get_conn(self, timeout=None):
+        self.semaphore.acquire(timeout=timeout)
+        conn = self._pool.pop()
+        if conn is None:
+            conn = psycopg2.connect(
+                host=self._host,
+                port=self._port,
+                dbname=self._dbname,
+                user=self._user,
+                password=self._password,
+            )
+        yield conn
+        self._pool.append(conn)
+        self.semaphore.release()
+
+    def close(self):
+        for conn in self._pool:
+            if conn:
+                conn.close()
+
+
+def with_cursor(timeout=None):
+    """
+    A handy way to save a pile of indent space and boiler plate to get a cursor.
+
+    Decorated functions will have `cursor` passed in as the first
+    argument.
+    """
+
+    def real_decorator(func):
+        @wraps(func)
+        def inner(*args, **kwargs):
+            if ENGINE is None:
+                error = "Must create a database object and run `init_app` before using `with_cursor`."
+                raise RuntimeError(error)
+            with ENGINE.get_conn(timeout=timeout) as conn:
+                with conn.cursor() as cursor:
+                    try:
+                        result = func(cursor, *args, **kwargs)
+                    except psycopg2.Error as doh:
+                        conn.rollback()
+                        raise doh from None
+                    else:
+                        conn.commit()
+                        return result
+
+        return inner
+
+    return real_decorator
+
+
+def rows_to_dicts(cursor):
+    """
+    Turn row tuples into normal Python dictionaries.
+
+    The options in `psycopg2.extras` are antiquated; vanilla Python
+    dictionaries have come a *long* way starting with Python 3.6.
+    """
+    column_names = [c.name for c in cursor.description]
+    rows = [dict(zip(column_names, row)) for row in cursor.fetchall()]
+    return rows
+
+
+@with_cursor()
+def example(cursor):
+    """
+    A placeholder example while I work on real ones ;)
+    """
+    sql = dedent(
+        """
+        SELECT relname
+        FROM pg_class
+        WHERE relkind='r'
+            AND relname !~ '^(pg_|sql_)'
+        """
+    )
+    cursor.execute(sql)
+    return rows_to_dicts(cursor)

--- a/sawmill_api/wsgi.py
+++ b/sawmill_api/wsgi.py
@@ -3,6 +3,7 @@ Gunicorn WSGI configuation.
 """
 
 import ssl
+import dataclasses
 
 
 keepalive = 30  # seconds
@@ -27,3 +28,13 @@ def ssl_context(address, port):
 # Logging
 errorlog = "-"  # stderr
 accesslog = "/dev/null"
+
+
+@dataclasses.dataclass(frozen=True)
+class OLTPDatabase:
+    host = "oltp"
+    port = 26257
+    user = "sawmill"
+    password = "a"
+    dbname = "sawmill"
+    max_connections = 10


### PR DESCRIPTION
This PR adds an interface so the API can use a transactional database. I still have to sort out schema migrations, and am leaning towards [DBMate](https://github.com/amacneil/dbmate), but we'll see.

One thing I didn't like from the start was the config file needed by Gunicorn. The more I have to muck with it, the more I'm wanting to totally hide it way from any real config file and then generate whatever Gunicorn needs based on that. But again, we'll see 😅.