### PR TITLE
Figured out DB migrations and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 ### Prerequisites
 To get started, you'll need Python3, Docker or Podman, the PostgreSQL header files installed (`libpq-dev` for Debian/Ubuntu, `postgresql-libs` for RHEL) and `make`.
 
-It's also **highly** recommened that you setup a [Python virtual environment](https://docs.python.org/3/tutorial/venv.html), but hey, it's your system.
+It's also **highly** recommend that you setup a [Python virtual environment](https://docs.python.org/3/tutorial/venv.html), but hey, it's your system.
 
-### Run
+### Run the following commands:
 
 1. `make bootstrap`
 2. `make images`
 3. `make up`
- *  To initialize the database, run: `docker compose exec -it oltp-1 ./cockroach --host=oltp-1:26357 init --insecure`
+4. `make migrate` (in a different tab/window)
+    - The app will constantly restart until the database is configured.
 
 You can now access the API via `https://localhost:8000`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,11 @@ services:
       - "8000:8000"
     volumes:
       - ./sawmill_api/:/usr/local/lib/python3.12/site-packages/sawmill_api/
+    restart: unless-stopped
+    depends_on:
+      - oltp
   oltp:
+    init: true
     image: cockroachdb/cockroach:latest-v25.2
     ports:
       - "8080:8080"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,6 @@ exclude = [
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["sawmill_api*"]
+
+[tool.setuptools.package-data]
+"sawmill_api" = ["migrations/*.sql"]

--- a/sawmill_api/app.py
+++ b/sawmill_api/app.py
@@ -1,7 +1,8 @@
 from flask import Flask
 
 from sawmill_api.handlers.planks import planks_api
-from sawmill_api import wsgi
+from sawmill_api.handlers.settings import settings_api
+from sawmill_api import wsgi, settings
 from sawmill_api.lib import oltp
 
 
@@ -9,6 +10,7 @@ def make_app():
     app = Flask(__name__)
     app.url_map.strict_slashes = False
     app.register_blueprint(planks_api)
+    app.register_blueprint(settings_api)
     db = oltp.BlockingConnectionPool(
         host=wsgi.OLTPDatabase.host,
         port=wsgi.OLTPDatabase.port,
@@ -18,6 +20,8 @@ def make_app():
         max_connections=wsgi.OLTPDatabase.max_connections,
     )
     db.init_app(app)
+    app_settings = oltp.get_api_settings()
+    settings.populate(grouped_by_section=app_settings)
 
     return app
 

--- a/sawmill_api/handlers/settings.py
+++ b/sawmill_api/handlers/settings.py
@@ -1,0 +1,57 @@
+from sawmill_api import utils, settings
+from sawmill_api.lib import oltp
+
+import flask
+import pydantic
+
+
+settings_api = flask.Blueprint("settings_api", __name__, url_prefix="/api/1/settings")
+log = utils.get_logger(__name__)
+
+# A bit long, but enables us to just add settings to module
+# and auto-magically reflect them in the API. Yay automation!
+SettingsAPI = pydantic.create_model(
+    "SettingsAPI",
+    **{
+        settings.title_to_dash(section_name): settings_section.__class__
+        for section_name, settings_section in list(settings)
+    },
+)
+
+
+@settings_api.route("/", methods=["GET"])
+def get_settings():
+    """Read the current settings being used by Sawmill."""
+    data = {}
+    for section_name, current_settings in list(settings):
+        data[settings.title_to_dash(section_name)] = current_settings
+    return SettingsAPI(**data).model_dump_json(), 200
+
+
+@settings_api.route("/<section>", methods=["PUT"])
+def update_setting(section):
+    """Override the default value of a setting"""
+    section_name = settings.dash_to_title(section)
+    instance = getattr(settings, section_name)
+    current_values = instance.model_dump()
+    new_values = flask.request.json
+    current_values.update(new_values)
+    new_instance = instance.__class__(**current_values)
+    oltp.set_api_setting(new_instance)
+    setattr(settings, section_name, new_instance)
+    return "", 204  # no content
+
+
+@settings_api.route("/<section>/<name>", methods=["DELETE"])
+def default_setting(section, name):
+    """Revert a setting to it's default value."""
+    section_name = settings.dash_to_title(section)
+    instance = getattr(settings, section_name)
+    current_values = instance.model_dump()
+    current_values.pop(name)
+    defaulted_values = instance.__class__().model_dump()
+    defaulted_values.update(current_values)
+    new_instance = instance.__class__(**defaulted_values)
+    oltp.set_api_setting(new_instance)
+    setattr(settings, section_name, new_instance)
+    return "", 204  # no content

--- a/sawmill_api/migrations/V20250618195438__api_settings.sql
+++ b/sawmill_api/migrations/V20250618195438__api_settings.sql
@@ -1,0 +1,8 @@
+CREATE SCHEMA api;
+
+CREATE TABLE api.settings(
+    section TEXT NOT NULL,
+    name TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (section, name)
+);

--- a/sawmill_api/settings.py
+++ b/sawmill_api/settings.py
@@ -1,0 +1,106 @@
+"""
+Enables Sawmill settings to change at runtime dynamically.
+
+The main idea behind this module is the ability to update
+settings without having to restart the application. It
+works by customizing attribute access and population.
+
+To get started, just import the module:
+
+>>> from sawmill_api import settings
+
+The settings are grouped into sections. Here's an example
+of accessing the settings for the `Planks` API handler:
+
+>>> settings.Planks.chunk_read_size
+
+Because modules are global in Python, if another handler
+updates a setting, the other modules use the new value the
+next time they reference it. Example:
+
+>>> settings.Planks.chunk_read_size
+8192
+>>> new_planks = settings.Planks.__class__(chunk_read_size=1024)
+>>> settattr(settings, 'Planks', new_planks)
+>>> settings.Planks.chunk_read_size
+1024
+"""
+
+import abc
+import pathlib
+import types
+import re
+import sys
+
+import pydantic
+
+
+class SettingsModule(types.ModuleType):
+    """A custom module to control attribute access."""
+
+    def populate(self, grouped_by_section: dict = None):
+        """
+        Create all the settings for Sawmill API.
+
+        :param grouped_by_section: Override values for the settings.
+        """
+        if grouped_by_section is None:
+            grouped_by_section = {}
+        for name in dir(_MODULE):
+            klass = getattr(_MODULE, name)
+            if isinstance(klass, type) and issubclass(klass, Section):
+                if klass is Section:
+                    name = klass.__name__
+                    section = klass
+                else:
+                    params = grouped_by_section.get(self.title_to_snake(name), {})
+                    section = klass(**params)
+                setattr(self, name, section)
+
+    @staticmethod
+    def title_to_snake(name: str) -> str:
+        """Convert TitleCase names to title_case."""
+        return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+    @staticmethod
+    def title_to_dash(name: str) -> str:
+        """Convert TitleNames to title-names"""
+        return re.sub(r"(?<!^)(?=[A-Z])", "-", name).lower()
+
+    @staticmethod
+    def dash_to_title(name: str) -> str:
+        """Convert dashed-names to DashedNames"""
+        return "".join(part.capitalize() for part in name.split("-"))
+
+    def __setattr__(self, name, value):
+        if not (isinstance(value, Section) or value is Section):
+            raise AttributeError(f"Unknown setting type: {value}")
+        super().__setattr__(name, value)
+
+    def __iter__(self):
+        for name, value in getattr(self, "__dict__").items():
+            if name.startswith("_") or value is Section:
+                continue
+            yield name, value
+
+
+class Section(abc.ABC):
+    """
+    A grouping of related settings.
+
+    Sections must be Pydantic models where every field has
+    a default value.
+    """
+
+    pass
+
+
+class Planks(pydantic.BaseModel, Section):
+    chunk_read_size: int = 8192
+    log_root: pathlib.Path = pathlib.Path("/var/log")
+
+
+# Replace the real module with the custom one.
+_MODULE = sys.modules[__name__]
+sys.modules[__name__] = SettingsModule(__name__)
+sys.modules[__name__].populate()


### PR DESCRIPTION
Turns out, [dbmate](https://github.com/amacneil/dbmate/issues/279) doesn't support cockroachdb. I found this out the "fun way" when the migrations kept failing due to something with the transaction state. So, I _sucked it up_ and switched to [flyway](https://www.cockroachlabs.com/docs/stable/flyway). I picked flyway solely for the fact that I've used it in the past and I have no issues with the Apache 2.0 license. 

Now that's out of the way, the fun stuff: actually using the database and sorting out "what do" about application settings! For the database, there are two different "make macros." One creates a new migration file, the other is for _running_ the migrations for local development.

As for the settings, I decided on these main aspects I wanted them to have:
* Every setting must have a (hopefully sane/reasonable) default value
* Users can override any setting
  *  which stores the user-defined value in the database
* Setting changes take effect immediately
  * I always groan when an app requires a reboot for a setting to _take effect_ 😒

Work on this makes me realize that I need to sort out a standard way to do API input/output validation. Something that makes it obvious _what_ an API returns, and something that can be programmatically leveraged to generate an OpenAPI spec. Either that, or adding dynamic log level changes is likely the next thing I work on. 